### PR TITLE
Fix clone of specific SCM version

### DIFF
--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -181,6 +181,11 @@ class RoleRequirement(RoleDefinition):
             raise AnsibleError("- scm %s is not currently supported" % scm)
         tempdir = tempfile.mkdtemp()
         clone_cmd = [scm, 'clone', src, name]
+        if version != 'HEAD':
+            if scm == 'git':
+                clone_cmd += ['-b', version]
+            elif scm == 'hg':
+                clone_cmd += ['-u', version]
         with open('/dev/null', 'w') as devnull:
             try:
                 popen = subprocess.Popen(clone_cmd, cwd=tempdir, stdout=devnull, stderr=devnull)


### PR DESCRIPTION
In a requirements.yml I had the following:

```

---

- src: https://mgitlab/mygroup/ansible-role-myrole.git
  scm: git
  version: somebranch
  name: myrole
```

The default branch of the repository was `develop`, and when `ansible-galaxy` was cloning the repository, the target branch wasn't fetched, resulting in a fail of the command `git archive`.

This fix adds to the clone command the option `-b <version>` for **git** and `-u <version>` for **mercurial** in order to prevent such problems.
